### PR TITLE
Remove extra blank line from interfaces docblock

### DIFF
--- a/src/CacheItemInterface.php
+++ b/src/CacheItemInterface.php
@@ -20,7 +20,6 @@ namespace Psr\Cache;
  * be requested from a Pool object via the getItem() method.  Calling Libraries
  * SHOULD NOT assume that an Item created by one Implementing Library is
  * compatible with a Pool from another Implementing Library.
- *
  */
 interface CacheItemInterface
 {

--- a/src/CacheItemPoolInterface.php
+++ b/src/CacheItemPoolInterface.php
@@ -10,7 +10,6 @@ namespace Psr\Cache;
  * It is also the primary point of interaction with the entire cache collection.
  * All configuration and initialization of the Pool is left up to an
  * Implementing Library.
- *
  */
 interface CacheItemPoolInterface
 {


### PR DESCRIPTION
Primarily by convention, secondly for consistency with the other PSR interfaces.
See the PSR-3 [LoggerInterface](https://github.com/php-fig/log/blob/master/Psr/Log/LoggerInterface.php) for instance.
