### PR TITLE
Corrected phpdoc bug

### DIFF
--- a/src/CacheItemInterface.php
+++ b/src/CacheItemInterface.php
@@ -78,7 +78,7 @@ interface CacheItemInterface
     /**
      * Sets the expiration time for this cache item.
      *
-     * @param \DateTimeInterface $expiration
+     * @param \DateTimeInterface|null $expiration
      *   The point in time after which the item MUST be considered expired.
      *   If null is passed explicitly, a default value MAY be used. If none is set,
      *   the value should be stored permanently or for as long as the
@@ -92,7 +92,7 @@ interface CacheItemInterface
     /**
      * Sets the expiration time for this cache item.
      *
-     * @param int|\DateInterval $time
+     * @param int|\DateInterval|null $time
      *   The period of time from the present after which the item MUST be considered
      *   expired. An integer parameter is understood to be the time in seconds until
      *   expiration. If null is passed explicitly, a default value MAY be used.


### PR DESCRIPTION
The description explicitly allows `null`, but the actual doc does not. This has lead to confusion when implementing this spec.
