### PR TITLE
Create constant for reserved key characters

### DIFF
--- a/src/CacheItemPoolInterface.php
+++ b/src/CacheItemPoolInterface.php
@@ -14,6 +14,14 @@ namespace Psr\Cache;
 interface CacheItemPoolInterface
 {
     /**
+     * Characters which cannot be used in cache key.
+     *
+     * The following characters are reserved for future extensions and MUST NOT be 
+     * supported by implementing libraries
+     */
+    const RESERVED_KEY_CHARACTERS = '{}()/\@:';
+    
+    /**
      * Returns a Cache Item representing the specified key.
      *
      * This method must always return a CacheItemInterface object, even in case of


### PR DESCRIPTION
This would be very useful for having single source of truth of these characters. Currently, every caching library needs to hardcode these (to throw exception if $key contains them). And every user-land code using these libraries must hardcode these too (to sanitize them).