### PR TITLE
Add extends \Throwable interface to CacheException 

### DIFF
--- a/src/CacheException.php
+++ b/src/CacheException.php
@@ -5,6 +5,6 @@ namespace Psr\Cache;
 /**
  * Exception interface for all exceptions thrown by an Implementing Library.
  */
-interface CacheException
+interface CacheException extends \Throwable
 {
 }


### PR DESCRIPTION
I suggest updating CacheException and expanding it using the Throwable interface.