### PR TITLE
docs: Standardize the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository holds all interfaces related to [PSR-6 (Caching Interface)][psr-
 
 Note that this is not a Caching implementation of its own. It is merely interfaces that describe the components of a Caching mechanism.
 
-You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
+The installable [package][package-url] and [implementations][implementation-url] are listed on Packagist.
 
 [psr-url]: https://www.php-fig.org/psr/psr-6/
 [package-url]: https://packagist.org/packages/psr/cache

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 Caching Interface
 ==============
 
-This repository holds all interfaces related to [PSR-6 (Caching Interface)][psr-link].
+This repository holds all interfaces related to [PSR-6 (Caching Interface)][psr-url].
 
 Note that this is not a Caching implementation of its own. It is merely interfaces that describe the components of a Caching mechanism.
 
-You can find [implementations][implementation-link] and [installation instructions][package-link] for the specification on the packagist.
+You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
 
-[psr-link]: https://www.php-fig.org/psr/psr-6/
-[package-link]: https://packagist.org/packages/psr/cache
-[implementation-link]: https://packagist.org/providers/psr/cache-implementation
+[psr-url]: https://www.php-fig.org/psr/psr-6/
+[package-url]: https://packagist.org/packages/psr/cache
+[implementation-url]: https://packagist.org/providers/psr/cache-implementation

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-PSR Cache
-=========
+Caching Interface
+==============
 
-This repository holds all interfaces defined by
-[PSR-6](http://www.php-fig.org/psr/psr-6/).
+This repository holds all interfaces related to [PSR-6 (Caching Interface)][psr-link].
 
-Note that this is not a Cache implementation of its own. It is merely an
-interface that describes a Cache implementation. See the specification for more 
-details.
+Note that this is not a Caching implementation of its own. It is merely interfaces that describe the components of a Caching mechanism.
+
+You can find [implementations][implementation-link] and [installation instructions][package-link] for the specification on the packagist.
+
+[psr-link]: https://www.php-fig.org/psr/psr-6/
+[package-link]: https://packagist.org/packages/psr/cache
+[implementation-link]: https://packagist.org/providers/psr/cache-implementation


### PR DESCRIPTION
What:
Standardizes the README file providing a common language and an implementation link.

Why:
There are differences between PSR's READMEs in regarding language and the lacking of implementations references. So I've updated all READMEs using the https://github.com/php-fig/http-factory as base.