### PR TITLE
Add support for Throwable

### DIFF
--- a/src/CacheException.php
+++ b/src/CacheException.php
@@ -5,6 +5,12 @@ namespace Psr\Cache;
 /**
  * Exception interface for all exceptions thrown by an Implementing Library.
  */
-interface CacheException
-{
+if (interface_exists('Throwable')) {
+    interface CacheException extends \Throwable
+    {
+    }
+} else {
+    interface CacheException
+    {
+    }
 }


### PR DESCRIPTION
When running PHPStan and Psalm on my projects and libraries, they complain that "You cannot catch a Psr\Cache\CacheException because it is not a Throwable".

This PR fixes that and keeps compatibility with PHP 5. 

This is NOT a BC break since the intention of the interface has been clear in the doc block. 

> Exception interface for all exceptions thrown by an Implementing Library.

We can release this in a minor release if we wanted to. 