### PR TITLE
Bump branch-alias to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
Adding return types is a BC break. The branch-alias should be bumped so that projects that test with `minimum-stability: dev` don't break (symfony is broken right now)