### PR TITLE
Update argument type in PHPDoc block

### DIFF
--- a/src/CacheItemInterface.php
+++ b/src/CacheItemInterface.php
@@ -77,7 +77,7 @@ interface CacheItemInterface
     /**
      * Sets the expiration time for this cache item.
      *
-     * @param ?\DateTimeInterface $expiration
+     * @param \DateTimeInterface|null $expiration
      *   The point in time after which the item MUST be considered expired.
      *   If null is passed explicitly, a default value MAY be used. If none is set,
      *   the value should be stored permanently or for as long as the


### PR DESCRIPTION
This PR fixes consistency of nullable types definition in PHPDoc blocks.

Method `expiresAfter` has typed `@param int|\DateInterval|null $time`

Method `expiresAt` has typed `@param ?\DateTimeInterface $expiration`