### PR TITLE
Fix return as iterable<CacheItemInterface> to CacheItemPool::getItems

### DIFF
--- a/src/CacheItemPoolInterface.php
+++ b/src/CacheItemPoolInterface.php
@@ -41,7 +41,7 @@ interface CacheItemPoolInterface
      *   If any of the keys in $keys are not a legal value a \Psr\Cache\InvalidArgumentException
      *   MUST be thrown.
      *
-     * @return iterable<CacheItemInterface>
+     * @return iterable<string, CacheItemInterface>
      *   An iterable collection of Cache Items keyed by the cache keys of
      *   each item. A Cache item will be returned for each key, even if that
      *   key is not found. However, if no keys are specified then an empty

--- a/src/CacheItemPoolInterface.php
+++ b/src/CacheItemPoolInterface.php
@@ -41,7 +41,7 @@ interface CacheItemPoolInterface
      *   If any of the keys in $keys are not a legal value a \Psr\Cache\InvalidArgumentException
      *   MUST be thrown.
      *
-     * @return iterable
+     * @return iterable<CacheItemInterface>
      *   An iterable collection of Cache Items keyed by the cache keys of
      *   each item. A Cache item will be returned for each key, even if that
      *   key is not found. However, if no keys are specified then an empty


### PR DESCRIPTION
Fixes missing typehints for `\Psr\Cache\CacheItemPoolInterface::getItems`